### PR TITLE
Added logic to add new born creature to granger with hug

### DIFF
--- a/src/Apps/WurmAssistant/WurmAssistant3/Areas/Granger/LogFeedManager/SmileXamineProcessor.cs
+++ b/src/Apps/WurmAssistant/WurmAssistant3/Areas/Granger/LogFeedManager/SmileXamineProcessor.cs
@@ -768,12 +768,8 @@ namespace AldursLab.WurmAssistant3.Areas.Granger.LogFeedManager
                             Age = GrangerHelpers.ExtractCreatureAge(objectNameWithPrefixes),
                             Server = server,
                             InspectSkill = skill ?? 0,
+                            newBorn = newBorn
                         };
-
-                        if (newBorn)
-                        {
-                            creatureBuffer.newBorn = true;
-                        }
 
                         var fat = GrangerHelpers.TryParseCreatureNameIfLineContainsFat(objectNameWithPrefixes);
                         if (fat != null) creatureBuffer.SecondaryInfo = CreatureEntity.SecondaryInfoTag.Fat;


### PR DESCRIPTION
Currently each birth date has to be set manually.
With this it would possible to set the birth date to now with a hug-examine instead of an smile-examine.

What do you think? Is it something that should be added?